### PR TITLE
feat: integra firebase con autenticacion

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,37 +5,39 @@ import PanicButton from '@/components/PanicButton';
 import NeighborhoodStats from '@/components/NeighborhoodStats';
 import RecentAlerts from '@/components/RecentAlerts';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { auth, db } from '@/lib/firebase';
+import { doc, onSnapshot } from 'firebase/firestore';
 
 export default function HomeScreen() {
-  const [userName, setUserName] = useState('Vecino');
-  const [neighborhood, setNeighborhood] = useState('Sector Amanecer');
-  const [alertLevel, setAlertLevel] = useState('Moderado');
-  const [isLoading, setIsLoading] = useState(true);
+  const [profile, setProfile] = useState<any>(null);
 
-  // Simulate data loading
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsLoading(false);
-    }, 1500);
-    return () => clearTimeout(timer);
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+    const unsub = onSnapshot(doc(db, 'users', uid), snap => {
+      setProfile(snap.data());
+    });
+    return unsub;
   }, []);
+
+  const userName = profile?.name ?? 'Vecino';
+  const neighborhood = profile?.neighborhood ?? 'Sector Amanecer';
+  const alertLevel = profile?.alertLevel ?? 'Moderado';
 
   const handlePanicButtonPress = () => {
     if (Platform.OS !== 'web') {
-      // On native platforms, we'd implement haptic feedback
-      // Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
+      // On native platforms, implement haptic feedback if desired
     }
-    
+
     Alert.alert(
       '¿Activar Alerta de Emergencia?',
       'Esto notificará a todos los vecinos y autoridades de tu ubicación.',
       [
         { text: 'Cancelar', style: 'cancel' },
-        { 
-          text: 'ACTIVAR ALERTA', 
+        {
+          text: 'ACTIVAR ALERTA',
           style: 'destructive',
           onPress: () => {
-            // Here we would trigger the actual emergency alert
             Alert.alert('Alerta Activada', 'Las autoridades han sido notificadas y están en camino.');
           }
         },
@@ -50,20 +52,20 @@ export default function HomeScreen() {
           <Shield size={24} color="#0A3161" />
           <Text style={styles.headerTitle}>VigiVecino</Text>
         </View>
-        
+
         <View style={styles.welcomeSection}>
           <Text style={styles.welcomeText}>Hola, {userName}</Text>
           <Text style={styles.neighborhoodText}>{neighborhood}</Text>
           <View style={styles.alertLevelContainer}>
             <Text style={styles.alertLevelLabel}>Nivel de Alerta:</Text>
-            <View style={[styles.alertLevelBadge, { backgroundColor: alertLevel === 'Alto' ? '#E63946' : '#FCA311' }]}>
+            <View style={[styles.alertLevelBadge, { backgroundColor: alertLevel === 'Alto' ? '#E63946' : '#FCA311' }] }>
               <Text style={styles.alertLevelText}>{alertLevel}</Text>
             </View>
           </View>
         </View>
 
         <PanicButton onPress={handlePanicButtonPress} />
-        
+
         <View style={styles.quickActions}>
           <TouchableOpacity style={styles.actionButton}>
             <Bell size={24} color="#0A3161" />
@@ -83,9 +85,9 @@ export default function HomeScreen() {
           </TouchableOpacity>
         </View>
 
-        <NeighborhoodStats isLoading={isLoading} />
-        
-        <RecentAlerts isLoading={isLoading} />
+        <NeighborhoodStats />
+
+        <RecentAlerts />
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
+import '@/lib/firebase';
 
 export default function RootLayout() {
   useFrameworkReady();

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,20 @@
+import { useEffect, useState } from 'react';
 import { Redirect } from 'expo-router';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/lib/firebase';
 
-// Redirect to the home tab screen
 export default function Index() {
-  return <Redirect href="/(tabs)" />;
+  const [loading, setLoading] = useState(true);
+  const [user, setUser] = useState<any>(null);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, u => {
+      setUser(u);
+      setLoading(false);
+    });
+    return unsub;
+  }, []);
+
+  if (loading) return null;
+  return <Redirect href={user ? '/(tabs)' : '/login'} />;
 }

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet, Alert } from 'react-native';
+import { useRouter } from 'expo-router';
+import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';
+import { doc, setDoc } from 'firebase/firestore';
+import { auth, db } from '@/lib/firebase';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isRegister, setIsRegister] = useState(false);
+  const router = useRouter();
+
+  const handleAuth = async () => {
+    try {
+      if (isRegister) {
+        const cred = await createUserWithEmailAndPassword(auth, email, password);
+        await setDoc(doc(db, 'users', cred.user.uid), {
+          name: email.split('@')[0],
+          neighborhood: 'Barrio Central',
+          alertLevel: 'Moderado',
+        });
+      } else {
+        await signInWithEmailAndPassword(auth, email, password);
+      }
+      router.replace('/(tabs)');
+    } catch (e: any) {
+      Alert.alert('Error', e.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{isRegister ? 'Crear Cuenta' : 'Iniciar Sesión'}</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Correo electrónico"
+        autoCapitalize="none"
+        value={email}
+        onChangeText={setEmail}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Contraseña"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+      />
+      <Button title={isRegister ? 'Registrarse' : 'Ingresar'} onPress={handleAuth} />
+      <Text style={styles.toggle} onPress={() => setIsRegister(!isRegister)}>
+        {isRegister ? '¿Ya tienes cuenta? Inicia sesión' : '¿No tienes cuenta? Regístrate'}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16, backgroundColor: '#F8F9FA' },
+  title: { fontSize: 24, marginBottom: 24, textAlign: 'center', color: '#0A3161', fontWeight: 'bold' },
+  input: { borderWidth: 1, borderColor: '#CBD5E1', padding: 12, borderRadius: 8, marginBottom: 12, backgroundColor: '#FFFFFF' },
+  toggle: { marginTop: 16, color: '#0A3161', textAlign: 'center' },
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['babel-preset-expo'],
+  plugins: ['expo-router/babel'],
+};

--- a/components/NeighborhoodStats.tsx
+++ b/components/NeighborhoodStats.tsx
@@ -1,37 +1,22 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { TrendingUp, TrendingDown, TriangleAlert as AlertTriangle, Shield } from 'lucide-react-native';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
 
-type NeighborhoodStatsProps = {
-  isLoading: boolean;
-};
+export default function NeighborhoodStats() {
+  const [stats, setStats] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
 
-export default function NeighborhoodStats({ isLoading }: NeighborhoodStatsProps) {
-  // Mock data for statistics
-  const stats = {
-    incidents: {
-      count: 12,
-      change: -23,
-      period: 'último mes',
-    },
-    alerts: {
-      count: 8,
-      change: 15,
-      period: 'último mes',
-    },
-    response: {
-      time: '4.3 min',
-      change: -12,
-      period: 'promedio',
-    },
-    patrols: {
-      count: 18,
-      change: 30,
-      period: 'último mes',
-    },
-  };
+  useEffect(() => {
+    const unsub = onSnapshot(doc(db, 'stats', 'summary'), snap => {
+      setStats(snap.data());
+      setLoading(false);
+    });
+    return unsub;
+  }, []);
 
-  if (isLoading) {
+  if (loading) {
     return (
       <View style={styles.container}>
         <Text style={styles.sectionTitle}>Estadísticas del Barrio</Text>
@@ -42,6 +27,8 @@ export default function NeighborhoodStats({ isLoading }: NeighborhoodStatsProps)
       </View>
     );
   }
+
+  if (!stats) return null;
 
   return (
     <View style={styles.container}>
@@ -132,10 +119,7 @@ export default function NeighborhoodStats({ isLoading }: NeighborhoodStatsProps)
               ) : (
                 <TrendingUp size={14} color="#2A9D8F" />
               )}
-              <Text style={[
-                styles.statChangeText,
-                styles.statPositive
-              ]}>
+              <Text style={[styles.statChangeText, styles.statPositive]}>
                 {Math.abs(stats.patrols.change)}%
               </Text>
             </View>

--- a/components/RecentAlerts.tsx
+++ b/components/RecentAlerts.tsx
@@ -1,38 +1,32 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, FlatList, ActivityIndicator } from 'react-native';
 import { TriangleAlert as AlertTriangle, MapPin, Clock, ChevronRight } from 'lucide-react-native';
+import { collection, query, orderBy, limit, onSnapshot, Timestamp } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
 
-type RecentAlertsProps = {
-  isLoading: boolean;
-};
+function timeAgo(timestamp: Timestamp) {
+  const diff = Date.now() - timestamp.toDate().getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h`;
+}
 
-export default function RecentAlerts({ isLoading }: RecentAlertsProps) {
-  // Mock data for recent alerts
-  const alerts = [
-    {
-      id: '1',
-      type: 'Robo',
-      location: 'Av. Alemania 01160',
-      time: '15 min',
-      status: 'activa',
-    },
-    {
-      id: '2',
-      type: 'Sospechoso',
-      location: 'Calle Manuel Montt 850',
-      time: '32 min',
-      status: 'verificando',
-    },
-    {
-      id: '3',
-      type: 'Allanamiento',
-      location: 'Pablo Neruda 02150',
-      time: '2h',
-      status: 'resuelta',
-    },
-  ];
+export default function RecentAlerts() {
+  const [alerts, setAlerts] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  const getStatusColor = (status) => {
+  useEffect(() => {
+    const q = query(collection(db, 'alerts'), orderBy('createdAt', 'desc'), limit(5));
+    const unsub = onSnapshot(q, snap => {
+      const data = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+      setAlerts(data);
+      setLoading(false);
+    });
+    return unsub;
+  }, []);
+
+  const getStatusColor = (status: string) => {
     switch (status) {
       case 'activa':
         return '#E63946';
@@ -45,7 +39,7 @@ export default function RecentAlerts({ isLoading }: RecentAlertsProps) {
     }
   };
 
-  const renderAlertItem = ({ item }) => (
+  const renderAlertItem = ({ item }: { item: any }) => (
     <TouchableOpacity style={styles.alertItem}>
       <View style={styles.alertHeader}>
         <View style={styles.alertTypeContainer}>
@@ -59,16 +53,18 @@ export default function RecentAlerts({ isLoading }: RecentAlertsProps) {
           <MapPin size={14} color="#64748B" />
           <Text style={styles.detailText} numberOfLines={1}>{item.location}</Text>
         </View>
-        <View style={styles.detailRow}>
-          <Clock size={14} color="#64748B" />
-          <Text style={styles.detailText}>Hace {item.time}</Text>
-        </View>
+        {item.createdAt && (
+          <View style={styles.detailRow}>
+            <Clock size={14} color="#64748B" />
+            <Text style={styles.detailText}>Hace {timeAgo(item.createdAt)}</Text>
+          </View>
+        )}
       </View>
       <ChevronRight size={16} color="#64748B" />
     </TouchableOpacity>
   );
 
-  if (isLoading) {
+  if (loading) {
     return (
       <View style={styles.container}>
         <Text style={styles.sectionTitle}>Alertas Recientes</Text>


### PR DESCRIPTION
## Summary
- configura Babel para Expo Router
- añade pantalla de login con Firebase Auth
- reemplaza mocks en inicio por datos de Firestore

## Testing
- `npm run lint` *(falla: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689bd427ea548321a5350d1887a16c3f