### PR TITLE
chore: configure babel

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel', 'expo-router/babel', 'react-native-reanimated/plugin'],
+  };
+};


### PR DESCRIPTION
## Summary
- add Babel configuration for Expo, NativeWind, Expo Router and Reanimated

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_689d1f1db3e08321a6563d9637c3b950