### PR TITLE
Configurar NativeWind en Babel y TypeScript

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,7 @@ module.exports = function (api) {
       ['babel-preset-expo', { jsxImportSource: 'nativewind' }],
     ],
     plugins: [
+      'nativewind/babel',
       'react-native-reanimated/plugin',
     ],
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "jsxImportSource": "nativewind",
     "paths": {
       "@/*": [
         "./*"


### PR DESCRIPTION
## Resumen
- Agregar el plugin `nativewind/babel` antes del plugin de Reanimated en la configuración de Babel
- Configurar `jsxImportSource` con `nativewind` en `tsconfig.json`

## Pruebas
- `npm test` *(falla: Missing script "test")*
- `npm run lint` *(falla: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689d2daf08408321b6d4a79138582259