### PR TITLE
Corrige identificadores de la app a vigivecino

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,11 +1,11 @@
 {
   "expo": {
-    "name": "bolt-expo-nativewind",
-    "slug": "bolt-expo-nativewind",
+    "name": "vigivecino",
+    "slug": "vigivecino",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "myapp",
+    "scheme": "vigivecino",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {


### PR DESCRIPTION
## Summary
- ajusta name, slug, scheme y paquetes nativos a los definitivos de Vigivecino

## Testing
- `npx expo prebuild --platform android --no-install`
- `CI=1 npx expo prebuild --platform ios --no-install`
- `npm test` *(falla: Missing script "test")*
- `npm run lint` *(falla: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689d2f35c9e08321901c0fb497a0151f