### PR TITLE
Refactor: estabiliza limpiadores de errores

### DIFF
--- a/hooks/useAuthValidation.ts
+++ b/hooks/useAuthValidation.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 
 interface ValidationErrors {
   [key: string]: string;
@@ -160,17 +160,17 @@ export function useAuthValidation() {
     return isValid;
   };
 
-  const clearError = (field: string) => {
+  const clearError = useCallback((field: string) => {
     setErrors(prev => {
       const newErrors = { ...prev };
       delete newErrors[field];
       return newErrors;
     });
-  };
+  }, []);
 
-  const clearAllErrors = () => {
+  const clearAllErrors = useCallback(() => {
     setErrors({});
-  };
+  }, []);
 
   return {
     errors,


### PR DESCRIPTION
## Resumen
- envuelve clearError y clearAllErrors con useCallback para referencias estables
- mantiene clearAllErrors como dependencia estable en ProfileEditModal

## Testing
- `npm run lint` *(falla: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e6823e7e483219eb85a803eab817d