### PR TITLE
Ensure email shown in profile and confirm profile saves

### DIFF
--- a/components/ProfileEditModal.tsx
+++ b/components/ProfileEditModal.tsx
@@ -58,7 +58,7 @@ export default function ProfileEditModal({ visible, onClose }: ProfileEditModalP
     setIsSaving(true);
     try {
       await updateProfile(formData);
-      Alert.alert('Perfil Actualizado', 'Tu información ha sido actualizada exitosamente.', [
+      Alert.alert('Datos guardados', 'Tu perfil se actualizó correctamente.', [
         { text: 'OK', onPress: onClose },
       ]);
     } catch (error) {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -6,6 +6,7 @@ import {
   createUserWithEmailAndPassword,
   signOut,
   sendPasswordResetEmail,
+  User as FirebaseUser,
 } from 'firebase/auth';
 
 import {
@@ -52,7 +53,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       // Firebase auth state listener
       const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
         if (firebaseUser) {
-          await loadUserProfile(firebaseUser.uid);
+          await loadUserProfile(firebaseUser);
         } else {
           setAuthState({
             user: null,
@@ -73,15 +74,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   };
 
-  const loadUserProfile = async (uid: string) => {
+  const loadUserProfile = async (firebaseUser: FirebaseUser) => {
     try {
-      const userDoc = await getDoc(doc(db, 'users', uid));
+      const uid = firebaseUser.uid;
+      const userRef = doc(db, 'users', uid);
+      const userDoc = await getDoc(userRef);
 
       if (userDoc.exists()) {
         const userData = userDoc.data();
+        let email = userData.email ?? firebaseUser.email ?? '';
+        if (!userData.email && firebaseUser.email) {
+          await updateDoc(userRef, { email });
+        }
         const user: User = {
           uid,
-          email: userData.email,
+          email,
           name: userData.name,
           rut: userData.rut,
           phone: userData.phone,


### PR DESCRIPTION
## Summary
- Load email from Firebase auth when missing in Firestore and persist it
- Show confirmation alert after successfully saving profile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e678034a08321970a325b4ac80608